### PR TITLE
Moved 2025/26 index link from 'new' to 'old' experience 

### DIFF
--- a/prototype/app/views/prototype/v5-2/index/allocation-index.html
+++ b/prototype/app/views/prototype/v5-2/index/allocation-index.html
@@ -127,6 +127,40 @@
   </div>
 </div>
 
+
+    </div>
+  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+      <div class="card-container govuk-!-margin-top-5">
+        <div class="govuk-grid-column-two-thirds">
+          <span class="govuk-heading-s">
+          <a href="#" class="govuk-link">Adult skills fund for 2025 to 2026</a>
+          <p class="govuk-body govuk-!-margin-top-2">9 December 2025 <span class="govuk-tag govuk-tag--red">New</span></p>
+        </div>
+      <div class="govuk-grid-column-one-third">
+          <span class="govuk-heading-s govuk-!-text-align-right">£3,332,100.00</h3>
+      </div>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+      <div class="card-container govuk-!-margin-top-5">
+        <div class="govuk-grid-column-two-thirds">
+          <span class="govuk-heading-s">
+          <a href="#" class="govuk-link">Advanced learner loans for 2025 to 2026</a>
+          <p class="govuk-body govuk-!-margin-top-2">4 February 2026 <span class="govuk-tag govuk-tag--red">New</span></p>
+        </div>
+      <div class="govuk-grid-column-one-third">
+          <span class="govuk-heading-s govuk-!-text-align-right">£983,800.00</h3>
+      </div>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
   </div>
   <div class="govuk-grid-column-two-thirds">
   <div class="govuk-grid-row">
@@ -137,11 +171,13 @@
           <p class="govuk-body govuk-!-margin-top-2">21 March 2024 version 1 <span class="govuk-tag govuk-tag--red">New</span></p>
         </div>
       <div class="govuk-grid-column-one-third">
-          <span class="govuk-heading-s govuk-!-text-align-right">£2,896,200</h3>
+          <span class="govuk-heading-s govuk-!-text-align-right">£2,896,200.00</h3>
       </div>
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+
    <div class="govuk-grid-row">
       <div class="card-container">
         <div class="govuk-grid-column-two-thirds">
@@ -150,7 +186,7 @@
           <p class="govuk-body govuk-!-margin-top-2">Last updated 11 July 2024</p>
         </div>
       <div class="govuk-grid-column-one-third">
-          <span class="govuk-heading-s govuk-!-text-align-right">£875,650</h3>
+          <span class="govuk-heading-s govuk-!-text-align-right">£875,650.00</h3>
       </div>
     </div>
   </div>

--- a/prototype/app/views/prototype/v5-2/index/index.html
+++ b/prototype/app/views/prototype/v5-2/index/index.html
@@ -228,34 +228,7 @@
     </div>
   </div>
 
-   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  <div class="govuk-grid-row">
-      <div class="card-container">
-        <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-heading-m">
-          <a href="#" class="govuk-link">Adult skills fund for 2025 to 2026</a>
-          <p class="govuk-body govuk-!-margin-top-2">Last updated: 9 December 2025</p>
-        </div>
-      <div class="govuk-grid-column-one-third">
-          <span class="govuk-heading-m govuk-!-text-align-right">£3,332,100.00</span>
-      </div>
-    </div>
-  </div>
 
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-  <div class="govuk-grid-row">
-      <div class="card-container">
-        <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-heading-m">
-          <a href="#" class="govuk-link">Advanced learner loans for 2025 to 2026</a>
-          <p class="govuk-body govuk-!-margin-top-2">Last updated: 4 February 2026</p>
-        </div>
-      <div class="govuk-grid-column-one-third">
-          <span class="govuk-heading-m govuk-!-text-align-right">£983,800.00</span>
-      </div>
-    </div>
-  </div>
 
 
 {% endblock %}


### PR DESCRIPTION
To align the prototype with the dates used in testing scenarios