### PR TITLE
Updates following content review

### DIFF
--- a/prototype/app/views/index.html
+++ b/prototype/app/views/index.html
@@ -48,9 +48,6 @@
             <br>
             <a class="govuk-button govuk-button--secondary" href="/prototype/v9/detailed-grouped-calculations.html">Detailed grouped calculations</a>
             <br>
-            <a class="govuk-button govuk-button--secondary" href="/prototype/v9/ungrouped-calculations.html">Ungrouped calculations</a>
-            <br
-            <br>
           </td>
         </tr>
       </tbody>
@@ -460,8 +457,11 @@
       <li>
         <a class="govuk-link govuk-link--no-visited-state" href="research-rounds/round-7-calcs.html">Round 7 - calculations</a>
       </li>
-       <li>
-        <a class="govuk-link govuk-link--no-visited-state" href="research-rounds/round-8.html">Round 8 - Funding index & allocation statement with calculation factors</a>
+      <li>
+        <a class="govuk-link govuk-link--no-visited-state" href="research-rounds/round-8.html">Round 8 - funding index & allocation statement with calculation factors</a>
+      </li>
+      <li>
+        <a class="govuk-link govuk-link--no-visited-state" href="research-rounds/round-9.html">Round 9 - calculation operations</a>
       </li>
     </ul>
 

--- a/prototype/app/views/prototype/v9/detailed-grouped-calculations.html
+++ b/prototype/app/views/prototype/v9/detailed-grouped-calculations.html
@@ -305,7 +305,7 @@
 
   {{ govukDetails({
     classes: "govuk-!-margin-bottom-9",
-    summaryText: "Show calculations",
+    summaryText: "Show calculations by funding line",
     html: (
 
       govukTable({
@@ -1140,7 +1140,7 @@
         rows: [
           [
             { 
-              text: "Eligible minus students" 
+              text: "Eligible students" 
             },
             {
               text: "",
@@ -1257,7 +1257,85 @@
             }
           ]
         ]
-      })    
+      })
+      +
+     govukTable({
+        caption: "",
+        captionClasses: "govuk-table__caption--m",
+        classes: "govuk-!-margin-bottom-8",
+        firstCellIsHeader: false,
+        head: [
+          { 
+          text: "High value courses premium",
+          classes: "govuk-!-width-one-half"
+          },
+          {
+            text: "Calculation",
+            format: "numeric",
+            classes: "govuk-!-width-one-quarter"
+
+          },
+          { 
+            text: "Value", 
+            format: "numeric",
+            classes: "govuk-!-width-one-quarter"
+          }
+        ],
+        rows: [
+          [
+            { 
+              text: "High value courses premium funding" 
+            },
+            {
+              text: "",
+              format: "numeric"
+            },
+            { 
+              text: "£305,400",
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              text: "High value courses premium funding - construction" 
+            },
+            {
+              text: "+",
+              format: "numeric"
+            },
+            { 
+              text: "£202,240", 
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              text: "High value courses premium funding - uplift to full rate" 
+            },
+            {
+              text: "+",
+              format: "numeric"
+            },
+            { 
+              text: "£136,160", 
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              html: "<strong>Total</strong>" 
+            },
+            { 
+              html: "<strong>=</strong>",
+              format: "numeric"
+            },
+            { 
+              html: "<strong>£645,800</strong>", 
+              format: "numeric" 
+            }
+          ]
+        ]
+      })        
        +
      govukTable({
         caption: "",
@@ -1445,84 +1523,6 @@
             },
             { 
               html: "<strong>£136,160</strong>", 
-              format: "numeric" 
-            }
-          ]
-        ]
-      })    
-       +
-     govukTable({
-        caption: "",
-        captionClasses: "govuk-table__caption--m",
-        classes: "govuk-!-margin-bottom-8",
-        firstCellIsHeader: false,
-        head: [
-          { 
-          text: "High value courses premium",
-          classes: "govuk-!-width-one-half"
-          },
-          {
-            text: "Calculation",
-            format: "numeric",
-            classes: "govuk-!-width-one-quarter"
-
-          },
-          { 
-            text: "Value", 
-            format: "numeric",
-            classes: "govuk-!-width-one-quarter"
-          }
-        ],
-        rows: [
-          [
-            { 
-              text: "High value courses premium funding" 
-            },
-            {
-              text: "",
-              format: "numeric"
-            },
-            { 
-              text: "£305,400",
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              text: "High value courses premium funding - construction" 
-            },
-            {
-              text: "+",
-              format: "numeric"
-            },
-            { 
-              text: "£202,240", 
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              text: "High value courses premium funding - uplift to full rate" 
-            },
-            {
-              text: "+",
-              format: "numeric"
-            },
-            { 
-              text: "£136,160", 
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              html: "<strong>Total</strong>" 
-            },
-            { 
-              html: "<strong>=</strong>",
-              format: "numeric"
-            },
-            { 
-              html: "<strong>£645,800</strong>", 
               format: "numeric" 
             }
           ]
@@ -1757,6 +1757,84 @@
             },
             { 
               html: "<strong>£960,000</strong>", 
+              format: "numeric" 
+            }
+          ]
+        ]
+      })
+        +
+     govukTable({
+        caption: "",
+        captionClasses: "govuk-table__caption--m",
+        classes: "govuk-!-margin-bottom-8",
+        firstCellIsHeader: false,
+        head: [
+          { 
+          text: "Student financial support",
+          classes: "govuk-!-width-one-half"
+          },
+          {
+            text: "Calculation",
+            format: "numeric",
+            classes: "govuk-!-width-one-quarter"
+
+          },
+          { 
+            text: "Value", 
+            format: "numeric",
+            classes: "govuk-!-width-one-quarter"
+          }
+        ],
+        rows: [
+          [
+            { 
+              text: "Discretionary bursary fund"
+            },
+            {
+              text: "",
+              format: "numeric"
+            },
+            { 
+              text: "£1,421,197",
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              text: "Residential support scheme" 
+            },
+            {
+              text: "+",
+              format: "numeric"
+            },
+            { 
+              text: "£3,631", 
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              text: "Free meals funding" 
+            },
+            {
+              text: "+",
+              format: "numeric"
+            },
+            { 
+              text: "£490,233", 
+              format: "numeric" 
+            }
+          ],
+          [
+            { 
+              html: "<strong>Total</strong>" 
+            },
+            { 
+              html: "<strong>=</strong>",
+              format: "numeric"
+            },
+            { 
+              html: "<strong>£1,915,061</strong>", 
               format: "numeric" 
             }
           ]
@@ -2035,84 +2113,6 @@
           ]
         ]
       })    
-       +
-     govukTable({
-        caption: "",
-        captionClasses: "govuk-table__caption--m",
-        classes: "govuk-!-margin-bottom-8",
-        firstCellIsHeader: false,
-        head: [
-          { 
-          text: "Student financial support",
-          classes: "govuk-!-width-one-half"
-          },
-          {
-            text: "Calculation",
-            format: "numeric",
-            classes: "govuk-!-width-one-quarter"
-
-          },
-          { 
-            text: "Value", 
-            format: "numeric",
-            classes: "govuk-!-width-one-quarter"
-          }
-        ],
-        rows: [
-          [
-            { 
-              text: "Discretionary bursary fund"
-            },
-            {
-              text: "",
-              format: "numeric"
-            },
-            { 
-              text: "£1,421,197",
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              text: "Residential support scheme" 
-            },
-            {
-              text: "+",
-              format: "numeric"
-            },
-            { 
-              text: "£3,631", 
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              text: "Free meals funding" 
-            },
-            {
-              text: "+",
-              format: "numeric"
-            },
-            { 
-              text: "£490,233", 
-              format: "numeric" 
-            }
-          ],
-          [
-            { 
-              html: "<strong>Total</strong>" 
-            },
-            { 
-              html: "<strong>=</strong>",
-              format: "numeric"
-            },
-            { 
-              html: "<strong>£1,915,061</strong>", 
-              format: "numeric" 
-            }
-          ]
-        ]
-      })
       +
      govukTable({
         caption: "",

--- a/prototype/app/views/prototype/v9/minimal-grouped-calculations.html
+++ b/prototype/app/views/prototype/v9/minimal-grouped-calculations.html
@@ -305,7 +305,7 @@
 
   {{ govukDetails({
     classes: "govuk-!-margin-bottom-9",
-    summaryText: "Show calculations",
+    summaryText: "Show calculations by funding line",
     html: (
 
       govukTable({
@@ -548,7 +548,7 @@
               format: "numeric"
             },
             { 
-              text: "",
+              text: "23",
               format: "numeric" 
             }
           ],

--- a/prototype/app/views/research-rounds/round-9.html
+++ b/prototype/app/views/research-rounds/round-9.html
@@ -16,11 +16,7 @@
       </li>
       <li>
         <a class="govuk-link govuk-link--no-visited-state" href="../../prototype/v9/detailed-grouped-calculations">Calculations 2</a>
-      </li>
-      <li>
-        <a class="govuk-link govuk-link--no-visited-state" href="../../prototype/v9/ungrouped-calculations" >Calculations 3</a>
-      </li>
-      
+      </li>    
     </ul>
     
 </div>


### PR DESCRIPTION
Updates made
- [x] Added missing value for eligible minus baseline students
- [x] “Show calculations by funding line” title for minimal grouped & detailed grouped
- [x] Updated order of tables so level 1 calcs are always shows before level 2 calcs
- [x] Link to research landing page from homepage
- [x] Removed ungrouped calcs from research landing page & index page as no longer testing